### PR TITLE
Manage substitute characters to support dash in the field names of the complex types and propose a workaround of the hive issue

### DIFF
--- a/src/main/java/com/ibm/spss/hive/serde2/xml/objectinspector/XmlObjectInspectorFactory.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/objectinspector/XmlObjectInspectorFactory.java
@@ -18,6 +18,7 @@ package com.ibm.spss.hive.serde2.xml.objectinspector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
@@ -50,22 +51,22 @@ public class XmlObjectInspectorFactory {
      *            the XML processor
      * @return the standard java object inspector
      */
-    public static ObjectInspector getStandardJavaObjectInspectorFromTypeInfo(TypeInfo typeInfo, XmlProcessor xmlProcessor) {
+    public static ObjectInspector getStandardJavaObjectInspectorFromTypeInfo(TypeInfo typeInfo, XmlProcessor xmlProcessor, Map<String, String> structReplacementChars) {
         switch (typeInfo.getCategory()) {
             case PRIMITIVE: {
                 return PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory());
             }
             case LIST: {
                 ObjectInspector listElementObjectInspector = getStandardJavaObjectInspectorFromTypeInfo(((ListTypeInfo) typeInfo).getListElementTypeInfo(),
-                    xmlProcessor);
+                    xmlProcessor, structReplacementChars);
                 return new XmlListObjectInspector(listElementObjectInspector, xmlProcessor);
             }
             case MAP: {
                 MapTypeInfo mapTypeInfo = (MapTypeInfo) typeInfo;
                 ObjectInspector mapKeyObjectInspector = getStandardJavaObjectInspectorFromTypeInfo(mapTypeInfo.getMapKeyTypeInfo(),
-                    xmlProcessor);
+                    xmlProcessor, structReplacementChars);
                 ObjectInspector mapValueObjectInspector = getStandardJavaObjectInspectorFromTypeInfo(mapTypeInfo.getMapValueTypeInfo(),
-                    xmlProcessor);
+                    xmlProcessor, structReplacementChars);
                 return new XmlMapObjectInspector(mapKeyObjectInspector, mapValueObjectInspector, xmlProcessor);
             }
             case STRUCT: {
@@ -74,9 +75,9 @@ public class XmlObjectInspectorFactory {
                 List<TypeInfo> fieldTypeInfos = structTypeInfo.getAllStructFieldTypeInfos();
                 List<ObjectInspector> structFieldObjectInspectors = new ArrayList<ObjectInspector>(fieldTypeInfos.size());
                 for (int fieldIndex = 0; fieldIndex < fieldTypeInfos.size(); ++fieldIndex) {
-                    structFieldObjectInspectors.add(getStandardJavaObjectInspectorFromTypeInfo(fieldTypeInfos.get(fieldIndex), xmlProcessor));
+                    structFieldObjectInspectors.add(getStandardJavaObjectInspectorFromTypeInfo(fieldTypeInfos.get(fieldIndex), xmlProcessor, structReplacementChars));
                 }
-                return getStandardStructObjectInspector(structFieldNames, structFieldObjectInspectors, xmlProcessor);
+                return getStandardStructObjectInspector(structFieldNames, structFieldObjectInspectors, xmlProcessor, structReplacementChars);
             }
             default: {
                 throw new IllegalStateException();
@@ -97,8 +98,8 @@ public class XmlObjectInspectorFactory {
      */
     public static StructObjectInspector getStandardStructObjectInspector(List<String> structFieldNames,
         List<ObjectInspector> structFieldObjectInspectors,
-        XmlProcessor xmlProcessor) {
-        return new XmlStructObjectInspector(structFieldNames, structFieldObjectInspectors, xmlProcessor);
+        XmlProcessor xmlProcessor,  Map<String, String> structReplacementChars) {
+        return new XmlStructObjectInspector(structFieldNames, structFieldObjectInspectors, xmlProcessor, structReplacementChars);
     }
 
 }

--- a/src/main/java/com/ibm/spss/hive/serde2/xml/objectinspector/XmlStructObjectInspector.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/objectinspector/XmlStructObjectInspector.java
@@ -18,6 +18,7 @@ package com.ibm.spss.hive.serde2.xml.objectinspector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
@@ -33,63 +34,88 @@ import com.ibm.spss.hive.serde2.xml.processor.XmlProcessor;
  * The struct object inspector
  */
 public class XmlStructObjectInspector extends StandardStructObjectInspector {
-    private static final Logger LOGGER = Logger.getLogger(XmlStructObjectInspector.class);
+	private static final Logger LOGGER = Logger.getLogger(XmlStructObjectInspector.class);
 
-    private XmlProcessor xmlProcessor = null;
+	private XmlProcessor xmlProcessor = null;
+	
+	private Map<String,String> structReplacementChars = null;
 
-    /**
-     * Creates the struct object inspector
-     * 
-     * @param structFieldNames
-     *            the struct field names
-     * @param structFieldObjectInspectors
-     *            the struct field object inspectors
-     * @param xmlProcessor
-     *            the XML processor
-     */
-    public XmlStructObjectInspector(List<String> structFieldNames,
-        List<ObjectInspector> structFieldObjectInspectors,
-        XmlProcessor xmlProcessor) {
-        super(structFieldNames, structFieldObjectInspectors);
-        this.xmlProcessor = xmlProcessor;
-    }
+	/**
+	 * Creates the struct object inspector
+	 * 
+	 * @param structFieldNames
+	 *            the struct field names
+	 * @param structFieldObjectInspectors
+	 *            the struct field object inspectors   
+	 *           
+	 * @param  structReplacementChars struct replacement chars 
+	 * @param xmlProcessor
+	 *            the XML processor
+	 */
+	public XmlStructObjectInspector(List<String> structFieldNames, List<ObjectInspector> structFieldObjectInspectors,
+			XmlProcessor xmlProcessor, Map<String,String> structReplacementChars) {
+		super(structFieldNames, structFieldObjectInspectors);
+		this.xmlProcessor = xmlProcessor;
+		this.structReplacementChars = structReplacementChars;
+	}
 
-    /**
-     * @see org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector#getStructFieldData(java.lang.Object,
-     *      org.apache.hadoop.hive.serde2.objectinspector.StructField)
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public Object getStructFieldData(Object data, StructField structField) {
-        if ((data instanceof List) && !(data instanceof SerDeArray)) {
-            MyField f = (MyField) structField;
-            int fieldID = f.getFieldID();
-            return ((List<Object>) data).get(fieldID);
-        } else {
-            ObjectInspector fieldObjectInspector = structField.getFieldObjectInspector();
-            Category category = fieldObjectInspector.getCategory();
-            Object fieldData = this.xmlProcessor.getObjectValue(data, structField.getFieldName());
-            switch (category) {
-                case PRIMITIVE: {
-                    PrimitiveObjectInspector primitiveObjectInspector = (PrimitiveObjectInspector) fieldObjectInspector;
-                    PrimitiveCategory primitiveCategory = primitiveObjectInspector.getPrimitiveCategory();
-                    return this.xmlProcessor.getPrimitiveObjectValue(fieldData, primitiveCategory);
-                }
-                default:
-                    return fieldData;
-            }
-        }
-    }
+	/**
+	 * @see org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector#getStructFieldData(java.lang.Object,
+	 *      org.apache.hadoop.hive.serde2.objectinspector.StructField)
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public Object getStructFieldData(Object data, StructField structField) {
+		if ((data instanceof List) && !(data instanceof SerDeArray)) {
+			MyField f = (MyField) structField;
+			int fieldID = f.getFieldID();
+			return ((List<Object>) data).get(fieldID);
+		} else {
+			ObjectInspector fieldObjectInspector = structField.getFieldObjectInspector();
+			Category category = fieldObjectInspector.getCategory();
+			
+			Object fieldData = getObjectValueForStructField(data, structField.getFieldName());
+			
+			switch (category) {
+			case PRIMITIVE: {
+				PrimitiveObjectInspector primitiveObjectInspector = (PrimitiveObjectInspector) fieldObjectInspector;
+				PrimitiveCategory primitiveCategory = primitiveObjectInspector.getPrimitiveCategory();
+				return this.xmlProcessor.getPrimitiveObjectValue(fieldData, primitiveCategory);
+			}
+			default:
+				return fieldData;
+			}
+		}
+	}
+	
+	/**
+	 * If no data found for the given fieldname, we try by replacing all chars identified in structReplacementChars.
+	 * This is a workaround for the hive bug : HIVE-13748.
+	 * 
+	 * @return return object value.
+	 */
+	private Object getObjectValueForStructField(Object data, String fieldName)
+	{
+		Object fieldData = this.xmlProcessor.getObjectValue(data, fieldName);
+		if (fieldData == null && !this.structReplacementChars.isEmpty()) {
+			String fieldNameNew =  fieldName;
+			for (Map.Entry<String, String> entry : this.structReplacementChars.entrySet()) {
+				fieldNameNew = fieldNameNew.replace(entry.getKey(), entry.getValue());
+			}
+			fieldData = this.xmlProcessor.getObjectValue(data, fieldNameNew);
+		}
+		return fieldData;
+	}
 
-    /**
-     * @see org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector#getStructFieldsDataAsList(java.lang.Object)
-     */
-    @Override
-    public List<Object> getStructFieldsDataAsList(Object data) {
-        List<Object> values = new ArrayList<Object>();
-        for (StructField structField : this.fields) {
-            values.add(getStructFieldData(data, structField));
-        }
-        return values;
-    }
+	/**
+	 * @see org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector#getStructFieldsDataAsList(java.lang.Object)
+	 */
+	@Override
+	public List<Object> getStructFieldsDataAsList(Object data) {
+		List<Object> values = new ArrayList<Object>();
+		for (StructField structField : this.fields) {
+			values.add(getStructFieldData(data, structField));
+		}
+		return values;
+	}
 }

--- a/src/main/java/com/ibm/spss/hive/serde2/xml/processor/XmlMapEntry.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/processor/XmlMapEntry.java
@@ -27,8 +27,6 @@ public class XmlMapEntry {
     /**
      * Creates an XML map entry specification for the custom XML to Map transformation
      * 
-     * @param fieldName
-     *            the field name
      * @param key
      *            the key specification
      * @param value

--- a/src/main/java/com/ibm/spss/hive/serde2/xml/processor/XmlProcessor.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/processor/XmlProcessor.java
@@ -36,8 +36,9 @@ public interface XmlProcessor {
     /**
      * Returns the mapping of the column names to the parsed objects
      * 
-     * @param text
-     *            the text to parse
+     * @param value 
+     * 		the text to parse
+     * 
      * @return the mapping of the column names to the parsed objects
      */
     public Map<String, ?> parse(String value);

--- a/src/main/java/com/ibm/spss/hive/serde2/xml/processor/XmlProcessorContext.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/processor/XmlProcessorContext.java
@@ -45,4 +45,5 @@ public interface XmlProcessorContext {
      * @return the properties
      */
     public Properties getProperties();
+    
 }

--- a/src/main/java/com/ibm/spss/hive/serde2/xml/processor/java/JavaXmlProcessor.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/processor/java/JavaXmlProcessor.java
@@ -74,6 +74,7 @@ public class JavaXmlProcessor implements XmlProcessor {
 
     private List<JavaXmlQuery> queries = new ArrayList<JavaXmlQuery>();
     private Map<String, XmlMapEntry> mapSpecification = null;
+    private Map<String, String> structReplacementChars = null;
 
     /**
      * @see com.ibm.spss.hive.serde2.xml.processor.XmlProcessor#initialize(com.ibm.spss.hive.serde2.xml.processor.XmlProcessorContext)
@@ -129,9 +130,7 @@ public class JavaXmlProcessor implements XmlProcessor {
         return result;
     }
 
-    /**
-     * @see com.ibm.spss.hive.serde2.xml.processor.java.XmlProcessor.XPathProcessor#getObjectValue(java.lang.Object, java.lang.String)
-     */
+
     @SuppressWarnings("rawtypes")
     @Override
     public Object getObjectValue(Object o, String fieldName) {
@@ -267,10 +266,6 @@ public class JavaXmlProcessor implements XmlProcessor {
         return stringBuilder.toString();
     }
 
-    /**
-     * @see com.ibm.spss.hive.serde2.xml.processor.java.XmlProcessor.XPathProcessor#getPrimitiveObjectValue(java.lang.Object,
-     *      org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory)
-     */
     @Override
     public Object getPrimitiveObjectValue(Object o, PrimitiveCategory primitiveCategory) {
         return XmlUtils.getPrimitiveValue(getStringValue(o), primitiveCategory);
@@ -468,4 +463,12 @@ public class JavaXmlProcessor implements XmlProcessor {
         }
         return null;
     }
+
+	/**
+	 * @return the structReplacementChars
+	 */
+	public Map<String, String> getStructReplacementChars() {
+		return structReplacementChars;
+	}
+
 }


### PR DESCRIPTION
Hi,

This pull request is linked with [Issue with xml node names containing a hyphen #51 ](https://github.com/dvasilen/Hive-XML-SerDe/issues/51).

I think the Hive issue https://issues.apache.org/jira/browse/HIVE-13748 won't be corrected soon because of its complexity.  So i propose you this workaround to have alternative solution than altering the source file when the xml file contains node names with an hyphen .

