### PR TITLE
Hive 2.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ibm.spss.hive.serde2.xml</groupId>
 	<artifactId>hivexmlserde</artifactId>
-	<version>1.0.5.3</version>
+	<version>1.0.5.4</version>
 	<packaging>jar</packaging>
 	<name>hive-xml-serde</name>
 	<url>https://github.com/dvasilen/Hive-XML-SerDe</url>
@@ -123,13 +123,13 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-serde</artifactId>
-			<version>1.2.0</version>
+			<version>2.3.5</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
-			<version>1.2.0</version>
+			<version>2.3.5</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/ibm/spss/hive/serde2/xml/XmlSerDe.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/XmlSerDe.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -47,7 +47,7 @@ import com.ibm.spss.hive.serde2.xml.processor.java.JavaXmlProcessor;
 /**
  * The XML serializer/deserializer for Apache Hive
  */
-public class XmlSerDe implements SerDe {
+public class XmlSerDe extends AbstractSerDe {
 
     private static final Logger LOGGER = Logger.getLogger(XmlSerDe.class);
     private static final String XML_PROCESSOR_CLASS = "xml.processor.class";


### PR DESCRIPTION
With hive v2, `SerDe` interface is replaced with `AbstractSerde` abstract class. This PR contains the required changes to make it work with hive 2.3.5. But it is not backward compatible. 