### PR TITLE
A fix for the unicode tags

### DIFF
--- a/src/main/java/com/ibm/spss/hive/serde2/xml/XmlInputFormat.java
+++ b/src/main/java/com/ibm/spss/hive/serde2/xml/XmlInputFormat.java
@@ -151,7 +151,7 @@ public class XmlInputFormat extends TextInputFormat {
                 if (withinBlock) {
                     this.buffer.write(b);
                 }
-                if (b == match[i]) {
+                if (b == (match[i] & 0xFF)) {
                     i++;
                     if (i >= match.length) {
                         return true;


### PR DESCRIPTION
A soon as read() returns only positive values (int range 0..255) and match[i] is signed (byte range -128...127) we have to cast.